### PR TITLE
Point to full length video of Graham talk

### DIFF
--- a/coffee/technology.coffee
+++ b/coffee/technology.coffee
@@ -1,2 +1,2 @@
 
-jQuery('#graham-talk').append '<iframe class="youtube-embed" width="560" height="315" src="//www.youtube.com/embed/FEC7g5OBhe0" frameborder="0"></iframe>'
+jQuery('#graham-talk').append '<iframe class="youtube-embed" width="560" height="315" src="//www.youtube.com/embed/GOC1Nad5dMg" frameborder="0"></iframe>'


### PR DESCRIPTION
The technology page points to a Youtube video that only has
the first 2 minutes. Point to the full length recording
instead.

https://www.youtube.com/watch?v=GOC1Nad5dMg

Save a bunch of click/search/click/facepalm...