### PR TITLE
Fix menu for talks listing page

### DIFF
--- a/_layouts/talks-listing.html
+++ b/_layouts/talks-listing.html
@@ -20,7 +20,7 @@
 	<header class="header">
 
 		<nav class="navigation">
-			<a class="navigation-item" href="/developers/index.html">Home</a> | <a class="navigation-item" href="/developers/developers.html">Our developers</a> | <a class="navigation-item" href="/developers/projects">Our projects</a> | <a href="/developers/technology.html">Technology</a> | <a class="navigation-item" href="/developers/work.html">Work with us</a> | <a class="navigation-item" href="/developers/talks.html">Talks and conferences</a> | <a class="navigation-item" href="/developers/faq.html">FAQ</a> | <a class="navigation-item" href="/developers/blog.html">Blog</a> | <a class="navigation-item" href="/developers/about.html">About</a>
+			<a class="navigation-item" href="/developers/index.html">Home</a> | <a class="navigation-item" href="/developers/developers.html">Our developers</a> | <a class="navigation-item" href="/developers/projects">Our projects</a> | <a href="/developers/technology.html">Technology</a> | <a class="navigation-item" href="/developers/devops.html">Devops</a> | <a class="navigation-item" href="/developers/work.html">Work with us</a> | <a class="navigation-item" href="/developers/talks.html">Talks and conferences</a> | <a class="navigation-item" href="/developers/social.html">Social</a> | <a class="navigation-item" href="/developers/faq.html">FAQ</a> | <a class="navigation-item" href="/developers/blog.html">Blog</a> | <a class="navigation-item" href="/developers/about.html">About</a>		</nav>
 		</nav>
 	</header>
 


### PR DESCRIPTION
The menu on the talks listing page didn't contain a link to the devops page - I have now attached it.