### PR TITLE
Avoids Mixed Content Requests

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,8 +14,8 @@
 		<link rel="stylesheet" href="{{ page.styling }}">
 		{% endif %}
 		<link rel="stylesheet" href="/css/shame.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,400italic' rel='stylesheet' type='text/css'>
-		<link rel="shortcut icon" href="http://static.guim.co.uk/favicon.ico" type="image/x-icon" />
+		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,400italic' rel='stylesheet' type='text/css'>
+		<link rel="shortcut icon" href="https://static.guim.co.uk/favicon.ico" type="image/x-icon" />
 		<script src="/js/coffee-script.js"></script>
 	</head>
 	<body class="{{page.class}}">


### PR DESCRIPTION
By default, Chrome blocks mixed content requests which causes the font stylesheet and favicon not to load. Updating to https:// urls should fix that.